### PR TITLE
GitHub Actionsの設定を修正して'Resource not accessible by integration'エラーを解消

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -15,5 +15,5 @@ jobs:
       uses: pozil/auto-assign-issue@v1
       with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          assignees: yuminn-k
+          assignees: ${{ github.event.pull_request.user.login }}
           numOfAssignee: 1


### PR DESCRIPTION
## 🔍 このPRで解決したい問題は何ですか？

GitHub Actionsで'Resource not accessible by integration'エラーが発生しました。このエラーは、GitHub Actionsが必要なリソースにアクセスできないときに発生します。

## ✨ このPRで主に変わったことは何ですか？

GitHub Actionsの設定コードを修正しました。具体的には、PRを作成したユーザーを自動的にassignするように変更しました。

## 🔖 主な変更点以外に追加で変更された部分はありますか？

なし

## 🙏🏻 Reviewerに特に見ていただきたい部分はありますか？

修正したGitHub Actionsの設定コードを確認してください。

## 🩺 このPRでテストや検証が必要な部分はありますか？

PR作成時に自動的に作成者がassignされるかどうかを確認するテストが必要です。

## 📚 関連するIssueやドキュメントのリンク

- related issue: #8 
- エラーメッセージ: `Resource not accessible by integration`
- Documentation URL: https://docs.github.com/rest/issues/assignees#add-assignees-to-an-issue

## 🖥 作動する様子

PR作成後のassignの状態を確認してください。

## 📌 PRを行う際の注意点

* Reviewerはコードレビュー時に良いコードの方向性を示しますが、コード修正を強制することはありません。
* Reviewerは良いコードを見つけた場合、賞賛と励ましを惜しみません。
* レビューは特別なケースでない限り、Reviewerに指定された時点から3日以内に行ってください。
* コメント作成時にPrefixにP1、P2、P3を書いていただくと、Assigneeがより明確にコメントに対して対応することができます。
  * P1 : 必ず反映してください (Request Changes) - 問題が発生したり、脆弱性が発見されたケースなど。
  * P2 : 反映を積極的に検討していただければと思います (コメント)。
  * P3 : こんな方法もあるんじゃないかな～などの些細な意見です (Chore)。
#

---
## 📝 AssigneeのためのCheckList
- [ ] GitHub Actionsの設定コードの確認
- [ ] PR作成者が自動的にassignされるかのテスト